### PR TITLE
Browser Automation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Browser Automation
 
-Basic browser automation techniques for the CS-5704 Testing workshop
+Basic browser automation techniques for the CS-3704 Development Environments and Testing workshop.

--- a/duckduckgo.js
+++ b/duckduckgo.js
@@ -36,10 +36,10 @@ async function postMessage(page, msg)
   const page = await browser.newPage()
 
   // Pretend you are a iPhone X
-  // await page.setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1');
-  // await page.setViewport({ width: 375, height: 812 });
+  await page.setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1');
+  await page.setViewport({ width: 375, height: 812 });
   await page.goto(ddgUrl, { waitUntil: 'networkidle2' })
-  await page.type('#search_form_input_homepage', 'Puppeteer')
+  await page.type('#searchbox_input', 'Puppeteer')
   await page.keyboard.press('Enter');
   
   await page.waitForSelector('h2 a');

--- a/test/search.js
+++ b/test/search.js
@@ -20,7 +20,7 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should be the correct url', async () => {
-        expect(await page.url()).to.eql('https://google.com/');
+        expect(await page.url()).to.eql('https://duckduckgo.com/');
     });
 
     it('should have the correct page title', async () => {
@@ -28,6 +28,6 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should have the page open', async () => {
-        expect(await page.isClosed()).to.eql(true);
+        expect(await page.isClosed()).to.eql(false);
     });
 });


### PR DESCRIPTION
Jackson Medina

On line 42 of the `duckduckgo.js` file, I had to change the selector to `#searchbox_input` since the original selector seems out of date.

I patched failing tests for the Browser Automation Workshop.