### PR TITLE
Suggestions for fixing failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Browser Automation
 
-Basic browser automation techniques for the CS-5704 Testing workshop
+Basic browser automation techniques for the CS-3704 Development Environments and Testing workshop.


### PR DESCRIPTION
Yasir Hassan (yasirh):
Changing the expected url from "https://google.com/" to "https://duckduckgo.com/', and the 'should have the page open' value from true to false.

![Screenshot 2024-04-06 185033](https://github.com/CS5704-VT/BrowserAutomation/assets/166188988/87534025-807b-4a82-a6e7-07408988637a)
